### PR TITLE
docs(deckrd): organize .deckrd internal design directory with sandbox docs

### DIFF
--- a/docs/.deckrd/.gitignore
+++ b/docs/.deckrd/.gitignore
@@ -1,0 +1,15 @@
+# src: .gitignore
+# @(#) : deckrd gitignore settings
+#
+# Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+# deckrd (micro framework of create specs)
+# temp directory
+**/temp/
+**/tmp/
+
+# session filles
+*session.json

--- a/docs/.deckrd/README.md
+++ b/docs/.deckrd/README.md
@@ -1,0 +1,25 @@
+# .deckrd
+
+This directory contains internal design and decision records
+used during development.
+
+- Documents under this directory are not part of the public API.
+- Decisions are recorded as DR (Decision Records).
+- This directory may be extracted as a standalone repository in the future.
+
+## notes/
+
+Documents under `notes/` are working notes and design drafts.
+
+- Contents are not stable.
+- They may be incomplete, outdated, or contradictory.
+- Information here may later be promoted to requirements or decision records.
+
+### How to Use
+
+- Use `notes/` to record working ideas, design explorations, and unresolved discussions.
+- Notes files should start with a datetime, e.g. `2025-12-26T21:38:00-about-agtKind.md`.
+- When a design decision is finalized, promote the content to:
+  - `decision-records/` for explicit design decisions (DR)
+  - `requirements/` for agreed functional or non-functional requirements
+- Do not treat documents under `notes/` as stable or authoritative.

--- a/docs/.deckrd/sandbox/greetings/requirements/requirements.md
+++ b/docs/.deckrd/sandbox/greetings/requirements/requirements.md
@@ -1,0 +1,112 @@
+---
+title: "Requirements: Greetings"
+Module: "sandbox/greetings"
+Status: Draft
+Version: 1.0
+Created: "2026-03-06"
+---
+
+> **Normative Statement**
+> This document defines binding requirements.
+> Implementations MUST conform to this document.
+> RFC 2119 keywords apply to this document only.
+
+## 1. Overview
+
+### 1.1 Purpose
+
+BDD のサンプル実装として、ユーザー名を受け取り `"Hello, <user>!"` 形式の挨拶文字列を返す `greetings` モジュールを Go で作成する。
+本モジュールは Go における BDD スタイルのテスト手法の学習・参照用実装を目的とする。
+
+### 1.2 Scope
+
+- Go パッケージ `greetings` の実装
+- ユーザー名を受け取り挨拶文字列を返す関数の実装
+- BDD スタイルによるテストの実装
+
+**Out of Scope**:
+
+- CLI インターフェース (コマンドライン引数による入力)
+- HTTP API やサーバー実装
+- 外部 BDD フレームワーク (godog 等) の使用
+- 出力言語の切り替え機能 (こんにちは、Bonjour 等の多言語挨拶テンプレート)
+
+## 2. Context
+
+- Target Environment: Go (最新安定版)
+- Related Components: `sandbox/greetings` モジュール
+- Assumptions:
+  - 標準ライブラリのみ使用
+
+## 3. Functional Requirements
+
+- FR-01: 挨拶関数はユーザー名を文字列で受け取り、挨拶文字列を返す SHALL
+- FR-02: ユーザー名 `"Alice"` を渡すと `"Hello, Alice!"` を返す SHALL
+- FR-03: ユーザー名の前後の空白をトリムする SHALL
+
+## 4. Non-Functional Requirements
+
+### 4.1 Quality
+
+- Maintainability: 関数は単一責務とし、テストと実装を明確に分離する
+- Testability: 全ケースを網羅的にテスト可能であること
+- Portability: 標準ライブラリのみ使用し、外部依存ゼロとする
+
+### 4.2 Constraints
+
+- Go 標準ライブラリのみ使用 (外部パッケージ禁止)
+- パッケージ名: `greetings`
+
+## 5. Change History
+
+| Date       | Version | Description     |
+| ---------- | ------- | --------------- |
+| 2026-03-06 | 1.0     | Initial release |
+
+## 6. User Stories
+
+| ID    | Role   | Goal                                           | Reason                                      |
+| ----- | ------ | ---------------------------------------------- | ------------------------------------------- |
+| US-01 | 開発者 | 挨拶関数にユーザー名を渡して挨拶文を取得したい | 挨拶ロジックを再利用可能な形で利用するため  |
+| US-02 | 開発者 | 複数パターンを網羅的に検証したい               | BDD スタイルのテストを学ぶため              |
+| US-03 | 学習者 | BDD の概念を Go で体験したい                   | 外部フレームワーク不要で BDD を理解するため |
+
+## 7. Acceptance Criteria
+
+```gherkin
+Scenario: 通常のユーザー名で挨拶を返す
+  Given ユーザー名 "Alice" が指定されている
+  When  挨拶関数を "Alice" で呼び出す
+  Then  "Hello, Alice!" が返される
+
+Scenario: 別のユーザー名で挨拶を返す
+  Given ユーザー名 "Bob" が指定されている
+  When  挨拶関数を "Bob" で呼び出す
+  Then  "Hello, Bob!" が返される
+
+Scenario: 日本語ユーザー名で挨拶を返す
+  Given ユーザー名 "太郎" が指定されている
+  When  挨拶関数を "太郎" で呼び出す
+  Then  "Hello, 太郎!" が返される
+
+Scenario: 空文字列で空の挨拶を返す
+  Given ユーザー名が空文字列 "" である
+  When  挨拶関数を "" で呼び出す
+  Then  "Hello, !" が返される
+
+Scenario: 前後に空白があるユーザー名はトリムして挨拶を返す
+  Given ユーザー名 "  Alice  " が指定されている
+  When  挨拶関数を "  Alice  " で呼び出す
+  Then  "Hello, Alice!" が返される
+
+Scenario: 空白のみのユーザー名は Hello,! を返す
+  Given ユーザー名が空白のみ "   " である
+  When  挨拶関数を "   " で呼び出す
+  Then  "Hello, !" が返される
+```
+
+## 8. Open Questions
+
+| Question                                                                               | Type | Impact Area | Owner  |
+| -------------------------------------------------------------------------------------- | ---- | ----------- | ------ |
+| 将来的に出力言語の切り替え機能 (Bonjour, こんにちは 等の挨拶テンプレート) を追加するか | 方針 | Scope       | 開発者 |

--- a/docs/.deckrd/sandbox/greetings/specifications/specifications.md
+++ b/docs/.deckrd/sandbox/greetings/specifications/specifications.md
@@ -1,0 +1,166 @@
+---
+title: "Design Specification: Greetings"
+Based on: requirements.md v1.0
+Status: Draft
+---
+
+## 1. Overview
+
+### 1.1 Purpose
+
+本仕様書は、`greetings` モジュールの **振る舞いルール** と **意味論** を定義する。
+ユーザー名を受け取り、トリム処理後に `"Hello, <name>!"` 形式の挨拶文字列を生成する処理の仕様を記述する。
+
+### 1.2 Scope
+
+本仕様書は `greetings` モジュールの **振る舞いルール** と **分類の意味論** を定義する。
+
+実装の詳細 (関数名・型・パッケージ構造等) は明示的にスコープ外とする。
+
+---
+
+## 2. Design Principles
+
+### 2.1 Classification Philosophy
+
+入力文字列をトリムし、結果を固定フォーマット `"Hello, <trimmed>!"` で返す単一変換処理として設計する。
+すべての入力値 (空文字列・空白のみを含む) を有効な入力として扱い、エラーや例外を発生させない。
+
+### 2.2 Design Assumptions
+
+- 入力は任意の Go `string` 値である (nil は存在しない)
+- 出力フォーマットは `"Hello, " + trimmed_name + "!"` で不変である
+- トリム対象は Unicode 空白文字 (U+0020 等) とする
+- 外部パッケージへの依存なし、標準ライブラリのみ使用する
+
+### 2.3 External Design Summary
+
+> **Source**: Derived from the external design dialogue (Phase E) and user-confirmed design direction (Phase D).
+
+#### Feature Decomposition
+
+| Unit                | Responsibility                                           | FR Coverage         |
+| ------------------- | -------------------------------------------------------- | ------------------- |
+| greeting generation | ユーザー名を受け取り、トリム後に挨拶文字列を生成して返す | FR-01, FR-02, FR-03 |
+
+#### Unit Interaction Map
+
+Units are independent; no ordering constraints.
+
+### 2.4 Non-Goals
+
+> **Derivation**: All items below originate from REQUIREMENTS Section "Out of Scope".
+
+- CLI インターフェースの提供 ← REQ: Out of Scope #1
+- HTTP API やサーバー実装 ← REQ: Out of Scope #2
+- 外部 BDD フレームワーク (godog 等) の使用 ← REQ: Out of Scope #3
+- 出力言語の切り替え機能 (多言語挨拶テンプレート) ← REQ: Out of Scope #4
+
+### 2.5 Behavioral Design Decisions
+
+<!-- markdownlint-disable line-length -->
+
+| ID    | Decision                                       | Rationale                                                              | Affected Rules | Status |
+| ----- | ---------------------------------------------- | ---------------------------------------------------------------------- | -------------- | ------ |
+| DD-01 | 空文字列・空白のみの入力もエラーなしで処理する | 要件にすべてのエッジケースが明示されており、エラー処理は不要と確認済み | Rule 4.1, 5.x  | Active |
+
+<!-- markdownlint-enable -->
+
+### 2.6 Related Decision Records
+
+> **Reference**: This section lists formal DRs that affect this specification.
+
+No Decision Records currently affect this specification.
+
+### 2.7 DD to DR Promotion Criteria
+
+> **Purpose**: Guidelines for determining when a DD should be promoted to a formal DR.
+
+**Consider promoting a DD when:**
+
+1. **Cross-specification Impact** — 複数の仕様書やモジュールに影響する決定
+2. **Architectural Significance** — 将来の設計選択を制約する決定
+3. **Non-trivial Alternatives** — 複数の実行可能な選択肢が存在した
+4. **Stakeholder Visibility Required** — 外部関係者がレビューすべき決定
+
+**Keep as DD when:**
+
+- 本仕様書のみに閉じたローカルな決定
+- 有意な代替案が存在しなかった
+- 根拠がコンテキストから自明
+
+> **Action**: To promote, run `/deckrd dr --add` with the DD context,
+> then update DD Status to `Promoted → DR-xx`.
+
+---
+
+## 3. Behavioral Specification
+
+### 3.1 Input Domain
+
+- Input Type: 文字列 (任意の Unicode 文字列)
+- Assumptions:
+  - すべての文字列値が有効な入力として受け入れられる
+  - 空文字列および空白のみの文字列も有効な入力である
+  - 日本語などのマルチバイト文字を含む文字列も有効な入力である
+
+### 3.2 Output Semantics
+
+- Output Meaning: `"Hello, <trimmed_name>!"` 形式の挨拶文字列
+- Possible Outcomes:
+  - 通常のユーザー名: `"Hello, Alice!"` (例: 入力 `"Alice"`)
+  - 空文字列入力: `"Hello, !"` (入力 `""`)
+  - 空白のみ入力: `"Hello, !"` (例: 入力 `"   "`)
+  - 前後空白付き入力: トリム後の名前で挨拶 (例: 入力 `"  Alice  "` → `"Hello, Alice!"`)
+  - マルチバイト文字入力: そのまま使用 (例: 入力 `"太郎"` → `"Hello, 太郎!"`)
+
+---
+
+## 4. Decision Rules
+
+Evaluation MUST follow this order:
+
+| Step | Condition                                | Outcome                                        |
+| ---: | ---------------------------------------- | ---------------------------------------------- |
+|    1 | 入力文字列の前後の空白をトリムする       | トリム済み文字列を得る                         |
+|    2 | トリム済み文字列を挨拶フォーマットに適用 | `"Hello, " + trimmed + "!"` の文字列を生成する |
+|    3 | 生成した挨拶文字列を返す                 | 呼び出し元に挨拶文字列を返す                   |
+
+No reordering is permitted.
+
+---
+
+## 5. Edge Cases
+
+| Input         | Classification    | Rationale                                                   |
+| ------------- | ----------------- | ----------------------------------------------------------- |
+| `""`          | `"Hello, !"`      | 空文字列のトリムは空文字列のまま; フォーマットを適用する    |
+| `"   "`       | `"Hello, !"`      | 空白のみはトリム後に空文字列になる; フォーマットを適用する  |
+| `"  Alice  "` | `"Hello, Alice!"` | 前後の空白をトリムし、残った `"Alice"` をフォーマットに適用 |
+| `"太郎"`      | `"Hello, 太郎!"`  | マルチバイト文字はトリム対象外; そのままフォーマットに適用  |
+
+---
+
+## 6. Requirements Traceability
+
+| Requirement ID | Covered By                                                                             |
+| -------------- | -------------------------------------------------------------------------------------- |
+| FR-01          | Section 3.1 (Input Domain), Section 3.2 (Output Semantics), Section 4 (Decision Rules) |
+| FR-02          | Section 3.2 (Possible Outcomes), Section 4 (Decision Rules Step 2)                     |
+| FR-03          | Section 4 (Decision Rules Step 1), Section 5 (Edge Cases)                              |
+
+---
+
+## 7. Open Questions
+
+> **Status**: COMPLETE
+
+None identified - all requirements are unambiguous.
+
+---
+
+## 8. Change History
+
+| Date       | Version | Description           |
+| ---------- | ------- | --------------------- |
+| 2026-03-06 | 1.0     | Initial specification |


### PR DESCRIPTION
## Summary

- `.deckrd/` ディレクトリを初期化し、内部設計・意思決定記録のフレームワーク構造を整備する
- `.deckrd/README.md` でディレクトリの位置づけと使用方法を定義する
- BDD学習用サンドボックスとして `sandbox/greetings` モジュールの要件定義・設計仕様を作成する
- deckrdフレームワーク専用の `.gitignore` でセッションファイル等を除外設定する

## Changes

### 新規追加ファイル

| ファイル | 内容 |
|---|---|
| `docs/.deckrd/.gitignore` | temp/、セッションファイル等を除外 |
| `docs/.deckrd/README.md` | .deckrdディレクトリの説明・方針・notes昇格フロー |
| `docs/.deckrd/sandbox/greetings/requirements/requirements.md` | greetingsモジュール要件定義（FR-01〜FR-03、Gherkin受け入れ基準） |
| `docs/.deckrd/sandbox/greetings/specifications/specifications.md` | greetings設計仕様（決定ルール、エッジケース、要件トレーサビリティ） |

## Background

`.deckrd/` は開発過程の内部設計と意思決定記録を保管するフレームワーク用ディレクトリです。
公開APIではなく、将来的に独立したリポジトリとして抽出される可能性があります。

今回の `sandbox/greetings` は、Go言語でBDDスタイルテストを学習・参照するための
サンプル実装用のドキュメントです。要件定義と設計仕様が完成し、
次のステップは実装フェーズとなります。

## Test Plan

- [x] `docs/.deckrd/README.md` の内容が正確で、ディレクトリ構造の説明が一致していることを確認
- [x] `requirements.md` のGherkin受け入れ基準が `specifications.md` の振る舞いルールと整合していることを確認
- [x] `.gitignore` が `*session.json` と `**/temp/` を正しく除外していることを確認
- [ ] 要件トレーサビリティ（FR-01〜FR-03が仕様にカバーされているか）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)